### PR TITLE
Cleaning up Board.spec.js

### DIFF
--- a/src/components/Board/Board.jsx
+++ b/src/components/Board/Board.jsx
@@ -47,14 +47,14 @@ class Board extends Component {
     this.setState({ cells: this.board.cellStates() })
   }
 
-  play (timeout = setTimeout, iterateFunc) {
+  play (iterateFunc) {
     if (this.isPlaying) {
       if (iterateFunc) {
         iterateFunc()
       } else {
         this.iterate()
       }
-      timeout(() => this.play(), 100)
+      setTimeout(() => this.play(), 100)
     }
   }
 

--- a/src/components/Board/Board.jsx
+++ b/src/components/Board/Board.jsx
@@ -54,7 +54,7 @@ class Board extends Component {
       } else {
         this.iterate()
       }
-      setTimeout(() => this.play(), 100)
+      setTimeout(() => this.play(iterateFunc), 100)
     }
   }
 

--- a/src/components/Board/Board.spec.js
+++ b/src/components/Board/Board.spec.js
@@ -119,18 +119,15 @@ describe('Board', () => {
         findCell(wrapper, 0, 1).simulate('click')
 
         clickButton(wrapper, 'iterate')
-
-        expect(getGenerationCount(wrapper)).toEqual(1)
-        expect(findCell(wrapper, 1, 1).prop('state')).toEqual(1)
-
         clickButton(wrapper, 'reset')
 
         expect(getGenerationCount(wrapper)).toEqual(0)
 
-        expect(findCell(wrapper, 0, 0).prop('state')).toEqual(0)
-        expect(findCell(wrapper, 1, 0).prop('state')).toEqual(0)
-        expect(findCell(wrapper, 0, 1).prop('state')).toEqual(0)
-        expect(findCell(wrapper, 1, 1).prop('state')).toEqual(0)
+        for(let i = 0; i < 2; i++) {
+          for (let j = 0; j < 2; j++) {
+            expect(findCell(wrapper, i, j).prop('state')).toBe(0)
+          }
+        }
       })
 
       it('clicking reset after play stops the iteration', () => {

--- a/src/components/Board/Board.spec.js
+++ b/src/components/Board/Board.spec.js
@@ -123,7 +123,7 @@ describe('Board', () => {
 
         expect(getGenerationCount(wrapper)).toEqual(0)
 
-        for(let i = 0; i < 2; i++) {
+        for (let i = 0; i < 2; i++) {
           for (let j = 0; j < 2; j++) {
             expect(findCell(wrapper, i, j).prop('state')).toBe(0)
           }

--- a/src/components/Board/Board.spec.js
+++ b/src/components/Board/Board.spec.js
@@ -48,31 +48,45 @@ describe('Board', () => {
       })
     })
 
+    describe('.play', () => {
+      it('iterates continuously', () => {
+        const board = new Board()
+        const mockIterate = jest.fn()
+        const playSpy = jest.spyOn(board, 'play')
+
+        board.isPlaying = true
+        board.play(mockIterate)
+
+        expect(mockIterate.mock.calls.length).toBe(1)
+
+        expect(setTimeout.mock.calls.length).toBe(1)
+        expect(setTimeout.mock.calls[0][1]).toBe(100)
+
+        expect(playSpy.mock.calls.length).toBe(1)
+        jest.runOnlyPendingTimers()
+        expect(playSpy.mock.calls.length).toBe(2)
+        expect(mockIterate.mock.calls.length).toBe(2)
+      })
+    })
+
     describe('play/pause buttons', () => {
-      describe('.play', () => {
-        it('iterates continuously', () => {
-          const board = new Board()
-          const mockIterate = jest.fn()
-          board.isPlaying = true
-          board.play(mockIterate)
-          expect(setTimeout.mock.calls.length).toBe(1)
-          expect(setTimeout.mock.calls[0][1]).toBe(100)
-          expect(mockIterate.mock.calls.length).toBe(1)
-        })
+      let playSpy
+
+      beforeEach(() => {
+        playSpy = jest.spyOn(wrapper.instance(), 'play')
+      })
+
+      it('click play should call play', () => {
+        clickButton(wrapper, 'play')
+
+        expect(playSpy.mock.calls.length).toBe(1)
       })
 
       it('pressing play twice should not speed up the iteration rate', () => {
         clickButton(wrapper, 'play')
         clickButton(wrapper, 'play')
 
-        expect(setTimeout.mock.calls.length).toBe(1)
-      })
-
-      it('should set a timed callback to play', () => {
-        clickButton(wrapper, 'play')
-
-        expect(setTimeout.mock.calls.length).toBe(1)
-        expect(setTimeout.mock.calls[0][1]).toBe(100)
+        expect(playSpy.mock.calls.length).toBe(1)
       })
 
       it('should allow to play after pausing', () => {
@@ -80,20 +94,22 @@ describe('Board', () => {
         clickButton(wrapper, 'pause')
         clickButton(wrapper, 'play')
 
-        expect(setTimeout.mock.calls.length).toBe(2)
+        expect(playSpy.mock.calls.length).toBe(2)
       })
     })
 
-    it('should resize the board', () => {
-      wrapper = mount(<Board />)
-      const form = wrapper.find('form')
-      const input = wrapper.find('input').at(0)
+    describe('resizing form', () => {
+      it('should resize the board', () => {
+        wrapper = mount(<Board />)
+        const form = wrapper.find('form')
+        const input = wrapper.find('input').at(0)
 
-      input.instance().value = 20
-      form.simulate('submit')
+        input.instance().value = 20
+        form.simulate('submit')
 
-      const total = 20 * 20
-      expect(wrapper.find('.board-div').children('Cell').length).toEqual(total)
+        const total = 20 * 20
+        expect(wrapper.find('.board-div').children('Cell').length).toEqual(total)
+      })
     })
 
     describe('reset button', () => {


### PR DESCRIPTION
The tests were a it of a mess and running really slowly.
The tests have been refactored to mock out setTimeout and to spy on the buttons interacting directly with the .play function so that we don't actually have to wait for a certain number of generations to occur.